### PR TITLE
feat(textnorm): MeaningPreset + HygienePreset (meaning-preserving normalization)

### DIFF
--- a/textnorm/doc.go
+++ b/textnorm/doc.go
@@ -4,8 +4,13 @@
 // DedupTokens(), RemoveStopwords(), and JoinTokens() helpers for explicit
 // normalization flows. SearchPreset(), CanonicalPreset(), DBSafePreset(),
 // and WithWidthFold() provide thin reusable presets for the common search,
-// canonical, and persistence-safe cases. The textnorm/stopwords subpackage
-// ships English/French/Italian stopword sets for use with RemoveStopwords.
+// canonical, and persistence-safe cases. MeaningPreset() builds fingerprints
+// that must preserve meaning ("s22+" ≠ "s22", "4.5" ≠ "45"; no token merging
+// or dedup, Latin-only diacritic stripping). HygienePreset() is payload-grade
+// byte hygiene (UTF-8, HTML entities, zero-width/control runes, whitespace)
+// that leaves case, punctuation, and diacritics untouched. The
+// textnorm/stopwords subpackage ships English/French/Italian stopword sets
+// for use with RemoveStopwords.
 //
 // Benchmarks and fuzz targets live in this package so you can measure and harden
 // the current implementation before any optimization work begins.

--- a/textnorm/fuzz_test.go
+++ b/textnorm/fuzz_test.go
@@ -105,6 +105,33 @@ func FuzzMeaningPreset(f *testing.F) {
 	})
 }
 
+func FuzzHygienePreset(f *testing.F) {
+	f.Add("Café \u200bCrème &amp; Co!")
+	f.Add("a\n\tb\x00c &#8203; &amp;amp;")
+	f.Fuzz(func(t *testing.T, in string) {
+		// No idempotency check: HTML-entity decoding is legitimately
+		// non-idempotent ("&amp;amp;" → "&amp;" → "&").
+		out, err := HygienePreset().Run(in)
+		if err != nil {
+			t.Fatalf("HygienePreset(%q): %v", in, err)
+		}
+		if !utf8.ValidString(out) {
+			t.Fatalf("invalid UTF-8 in output %q for input %q", out, in)
+		}
+		for _, r := range out {
+			if unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Cc, r) {
+				t.Fatalf("format/control rune %U in output %q for input %q", r, out, in)
+			}
+			if unicode.IsSpace(r) && r != ' ' {
+				t.Fatalf("non-collapsed whitespace %U in output %q for input %q", r, out, in)
+			}
+		}
+		if strings.Contains(out, "  ") || out != strings.TrimSpace(out) {
+			t.Fatalf("whitespace not collapsed/trimmed in %q", out)
+		}
+	})
+}
+
 func FuzzDBSafePreset(f *testing.F) {
 	for _, seed := range []string{
 		string([]byte{'g', 'o', 0x00, 0xff, '!', 0xfe}),

--- a/textnorm/fuzz_test.go
+++ b/textnorm/fuzz_test.go
@@ -1,7 +1,9 @@
 package textnorm
 
 import (
+	"strings"
 	"testing"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -77,6 +79,28 @@ func FuzzCanonicalPreset(f *testing.F) {
 		}
 		if out1 != out2 {
 			t.Fatalf("CanonicalPreset not idempotent: %q != %q", out1, out2)
+		}
+	})
+}
+
+func FuzzMeaningPreset(f *testing.F) {
+	f.Add("Galaxy S22+ 4.5\" 1,000 100%")
+	f.Add("c++ a+b % off 1.000")
+	f.Add("Café किताब مَكتَب")
+	f.Fuzz(func(t *testing.T, in string) {
+		out, err := MeaningPreset().Run(in)
+		if err != nil {
+			t.Fatalf("MeaningPreset(%q): %v", in, err)
+		}
+		for _, r := range out {
+			ok := unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsMark(r) || r == ' ' ||
+				r == '.' || r == ',' || r == '+' || r == '%'
+			if !ok {
+				t.Fatalf("illegal rune %q in output %q for input %q", r, out, in)
+			}
+		}
+		if strings.Contains(out, "  ") {
+			t.Fatalf("uncollapsed whitespace in %q", out)
 		}
 	})
 }

--- a/textnorm/hygiene.go
+++ b/textnorm/hygiene.go
@@ -1,6 +1,6 @@
-// Package textnorm — hygiene.go: byte-hygiene stages for text that will be
-// sent to an external model or stored verbatim. These stages never touch
-// case, punctuation, or diacritics.
+// Byte-hygiene stages for text that will be sent to an external model or
+// stored verbatim. These stages never touch case, punctuation, or diacritics.
+
 package textnorm
 
 import (

--- a/textnorm/hygiene.go
+++ b/textnorm/hygiene.go
@@ -1,0 +1,34 @@
+// Package textnorm — hygiene.go: byte-hygiene stages for text that will be
+// sent to an external model or stored verbatim. These stages never touch
+// case, punctuation, or diacritics.
+package textnorm
+
+import (
+	"html"
+	"strings"
+	"unicode"
+)
+
+// DecodeHTMLEntities appends an HTML-entity decoding stage ("&amp;" → "&").
+func (p Pipeline) DecodeHTMLEntities() Pipeline {
+	return p.Then(func(s string) (string, error) {
+		return html.UnescapeString(s), nil
+	})
+}
+
+// RemoveFormatChars appends a stage that drops Unicode format (Cf) and
+// control (Cc) runes — zero-width spaces, BiDi marks, NULs — except '\n' and
+// '\t', which downstream whitespace collapsing normalizes.
+func (p Pipeline) RemoveFormatChars() Pipeline {
+	return p.Then(func(s string) (string, error) {
+		var b strings.Builder
+		b.Grow(len(s))
+		for _, r := range s {
+			if r != '\n' && r != '\t' && (unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Cc, r)) {
+				continue
+			}
+			b.WriteRune(r)
+		}
+		return b.String(), nil
+	})
+}

--- a/textnorm/hygiene_test.go
+++ b/textnorm/hygiene_test.go
@@ -1,0 +1,24 @@
+package textnorm
+
+import "testing"
+
+func TestDecodeHTMLEntities(t *testing.T) {
+	got, err := New().DecodeHTMLEntities().Run("A &amp; B &#39;quoted&#39;")
+	if err != nil || got != "A & B 'quoted'" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestRemoveFormatChars(t *testing.T) {
+	in := "zero\u200bwidth bidi\u202e mark" // ZWSP + RLO
+	want := "zerowidth bidi mark"           // Cf runes dropped, letters untouched
+	got, err := New().RemoveFormatChars().Run(in)
+	if err != nil || got != want {
+		t.Fatalf("got %q err %v", got, err)
+	}
+	// \n and \t survive (whitespace collapse is a separate stage's job)
+	got, err = New().RemoveFormatChars().Run("a\n\tb\x00c")
+	if err != nil || got != "a\n\tbc" {
+		t.Fatalf("control handling: got %q err %v", got, err)
+	}
+}

--- a/textnorm/meaning.go
+++ b/textnorm/meaning.go
@@ -1,0 +1,59 @@
+// Package textnorm — meaning.go implements meaning-preserving punctuation
+// filtering: instead of deleting non-alphanumeric runes (which merges tokens,
+// e.g. "2.5"→"25"), every rejected rune becomes a single space, and the small
+// set of punctuation that carries meaning in product/search text is kept:
+//
+//   - '.' and ',' when BOTH neighbours are digits ("4.5", "1,000").
+//     Separators are NOT unified: "1,000" and "1.000" stay distinct because
+//     the same string means different numbers in different locales.
+//   - '+' when it terminates an alphanumeric token ("s22+", "c++").
+//   - '%' immediately after a digit ("100%").
+package textnorm
+
+import (
+	"strings"
+	"unicode"
+)
+
+// PreserveMeaningPunct appends the meaning-preserving punctuation stage.
+func (p Pipeline) PreserveMeaningPunct() Pipeline {
+	return p.Then(preserveMeaningPunct)
+}
+
+func preserveMeaningPunct(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	rs := []rune(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for i, r := range rs {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsSpace(r):
+			b.WriteRune(r)
+		case r == '.' || r == ',':
+			if i > 0 && i < len(rs)-1 && unicode.IsDigit(rs[i-1]) && unicode.IsDigit(rs[i+1]) {
+				b.WriteRune(r)
+			} else {
+				b.WriteByte(' ')
+			}
+		case r == '+':
+			prevOK := i > 0 && (unicode.IsLetter(rs[i-1]) || unicode.IsDigit(rs[i-1]) || rs[i-1] == '+')
+			nextOK := i == len(rs)-1 || unicode.IsSpace(rs[i+1]) || rs[i+1] == '+'
+			if prevOK && nextOK {
+				b.WriteRune(r)
+			} else {
+				b.WriteByte(' ')
+			}
+		case r == '%':
+			if i > 0 && unicode.IsDigit(rs[i-1]) {
+				b.WriteRune(r)
+			} else {
+				b.WriteByte(' ')
+			}
+		default:
+			b.WriteByte(' ')
+		}
+	}
+	return b.String(), nil
+}

--- a/textnorm/meaning.go
+++ b/textnorm/meaning.go
@@ -29,7 +29,10 @@ func preserveMeaningPunct(s string) (string, error) {
 	b.Grow(len(s))
 	for i, r := range rs {
 		switch {
-		case unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsSpace(r):
+		case unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsSpace(r) || unicode.IsMark(r):
+			// IsMark keeps combining marks (Devanagari matras, Arabic
+			// harakat) — they are vowels, not punctuation; Latin accents
+			// never reach here in MeaningPreset (stripped upstream).
 			b.WriteRune(r)
 		case r == '.' || r == ',':
 			if i > 0 && i < len(rs)-1 && unicode.IsDigit(rs[i-1]) && unicode.IsDigit(rs[i+1]) {

--- a/textnorm/meaning.go
+++ b/textnorm/meaning.go
@@ -1,13 +1,3 @@
-// Package textnorm — meaning.go implements meaning-preserving punctuation
-// filtering: instead of deleting non-alphanumeric runes (which merges tokens,
-// e.g. "2.5"→"25"), every rejected rune becomes a single space, and the small
-// set of punctuation that carries meaning in product/search text is kept:
-//
-//   - '.' and ',' when BOTH neighbours are digits ("4.5", "1,000").
-//     Separators are NOT unified: "1,000" and "1.000" stay distinct because
-//     the same string means different numbers in different locales.
-//   - '+' when it terminates an alphanumeric token ("s22+", "c++").
-//   - '%' immediately after a digit ("100%").
 package textnorm
 
 import (
@@ -15,7 +5,19 @@ import (
 	"unicode"
 )
 
-// PreserveMeaningPunct appends the meaning-preserving punctuation stage.
+// PreserveMeaningPunct appends the meaning-preserving punctuation stage:
+// instead of deleting non-alphanumeric runes (which merges tokens, e.g.
+// "2.5"→"25"), every rejected rune becomes a single space, and the small
+// set of punctuation that carries meaning in product/search text is kept:
+//
+//   - '.' and ',' when BOTH neighbours are digits ("4.5", "1,000").
+//     Separators are NOT unified: "1,000" and "1.000" stay distinct because
+//     the same string means different numbers in different locales.
+//   - '+' when it terminates an alphanumeric token ("s22+", "c++").
+//   - '%' immediately after a digit ("100%").
+//
+// Combining marks (Mn/Mc/Me) pass through — Devanagari matras and Arabic
+// harakat are vowels, not punctuation.
 func (p Pipeline) PreserveMeaningPunct() Pipeline {
 	return p.Then(preserveMeaningPunct)
 }

--- a/textnorm/meaning_test.go
+++ b/textnorm/meaning_test.go
@@ -1,0 +1,33 @@
+package textnorm
+
+import "testing"
+
+func TestPreserveMeaningPunct(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"decimal kept", "size 4.5", "size 4.5"},
+		{"decimal differs from int", "size 45", "size 45"},
+		{"thousands comma kept", "1,000", "1,000"},
+		{"separators not unified", "1.000", "1.000"},
+		{"space thousands untouched", "1 000", "1 000"},
+		{"trailing plus kept", "galaxy s22+", "galaxy s22+"},
+		{"cpp keeps plus chain", "c++", "c++"},
+		{"interior plus dropped", "a+b", "a b"},
+		{"percent after digit kept", "100% cotton", "100% cotton"},
+		{"percent standalone dropped", "% off", "  off"},
+		{"dot not between digits dropped", "end. next", "end  next"},
+		{"comma not between digits dropped", "red, blue", "red  blue"},
+		{"other punct to space not deleted", "2.5-GHz", "2.5 GHz"},
+		{"pipe to space", "a | b", "a   b"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := New().PreserveMeaningPunct().Run(c.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("PreserveMeaningPunct(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/textnorm/meaning_test.go
+++ b/textnorm/meaning_test.go
@@ -18,6 +18,8 @@ func TestPreserveMeaningPunct(t *testing.T) {
 		{"comma not between digits dropped", "red, blue", "red  blue"},
 		{"other punct to space not deleted", "2.5-GHz", "2.5 GHz"},
 		{"pipe to space", "a | b", "a   b"},
+		{"combining marks kept", "किताब", "किताब"},
+		{"arabic harakat kept", "مَكتَب", "مَكتَب"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/textnorm/presets.go
+++ b/textnorm/presets.go
@@ -76,6 +76,53 @@ func CanonicalPreset(opts ...PresetOption) Pipeline {
 		CollapseWhitespace()
 }
 
+// MeaningPreset builds a meaning-preserving normalization pipeline for
+// content fingerprinting (cache keys, dedup hashes) where "Galaxy S22+" must
+// NOT collide with "Galaxy S22" and "4.5" must NOT collide with "45".
+// Unlike SearchPreset it never merges tokens (rejected runes become spaces),
+// never dedups tokens, and strips diacritics only from Latin bases.
+func MeaningPreset(opts ...PresetOption) Pipeline {
+	cfg := presetConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	pipe := New().SanitizeUTF8().DecodeHTMLEntities().NormalizeUnicodeLatin()
+	if cfg.widthFold {
+		pipe = pipe.FoldWidth()
+	}
+
+	return pipe.
+		FoldCase().
+		PreserveMeaningPunct().
+		TrimSpace().
+		CollapseWhitespace()
+}
+
+// HygienePreset builds a byte-hygiene pipeline for text that is sent to an
+// external model or embedded verbatim: UTF-8 sanitize, HTML-entity decode,
+// format/control-rune removal, whitespace collapse. Case, punctuation, and
+// diacritics are preserved — this is deliberately the weakest cleaning level.
+func HygienePreset(opts ...PresetOption) Pipeline {
+	cfg := presetConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	pipe := New().SanitizeUTF8().DecodeHTMLEntities().RemoveFormatChars()
+	if cfg.widthFold {
+		pipe = pipe.FoldWidth()
+	}
+
+	return pipe.
+		TrimSpace().
+		CollapseWhitespace()
+}
+
 // DBSafePreset builds a persistence-safe normalization pipeline.
 func DBSafePreset(opts ...PresetOption) Pipeline {
 	cfg := presetConfig{}

--- a/textnorm/presets_test.go
+++ b/textnorm/presets_test.go
@@ -40,6 +40,62 @@ func TestDBSafePreset(t *testing.T) {
 	}
 }
 
+func TestMeaningPresetGoldens(t *testing.T) {
+	run := func(in string) string {
+		out, err := MeaningPreset().Run(in)
+		if err != nil {
+			t.Fatalf("MeaningPreset(%q): %v", in, err)
+		}
+		return out
+	}
+	cases := []struct{ name, in, want string }{
+		{"plus preserved", "Galaxy S22+", "galaxy s22+"},
+		{"decimal preserved", "size 4.5", "size 4.5"},
+		{"thousands preserved", "1,000", "1,000"},
+		{"percent preserved", "100% Cotton", "100% cotton"},
+		{"no token dedup", "Nike Air Air Max", "nike air air max"},
+		{"latin accents folded", "Hermès Café", "hermes cafe"},
+		{"indic preserved", "किताब", "किताब"},
+		{"entity decoded then spaced", "Dolce &amp; Gabbana", "dolce gabbana"},
+		{"punct to space collapses", "iPhone 13 | 128GB | Black", "iphone 13 128gb black"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := run(c.in); got != c.want {
+				t.Fatalf("MeaningPreset(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+	if run("Galaxy S22+") == run("Galaxy S22") {
+		t.Fatal("s22+ must differ from s22")
+	}
+	if run("size 4.5") == run("size 45") {
+		t.Fatal("4.5 must differ from 45")
+	}
+	if run("1,000") == run("1 000") {
+		t.Fatal("1,000 must differ from 1 000")
+	}
+}
+
+func TestHygienePresetGoldens(t *testing.T) {
+	run := func(in string) string {
+		out, err := HygienePreset().Run(in)
+		if err != nil {
+			t.Fatalf("HygienePreset(%q): %v", in, err)
+		}
+		return out
+	}
+	if got := run("Café \u200bCrème!"); got != "Café Crème!" {
+		t.Fatalf("hygiene must keep case/punct/diacritics, drop ZWSP: %q", got)
+	}
+	if got := run("A &amp; B"); got != "A & B" {
+		t.Fatalf("hygiene must decode entities: %q", got)
+	}
+	if got := run("  spaced\n\nout\t "); got != "spaced out" {
+		t.Fatalf("hygiene must collapse whitespace: %q", got)
+	}
+}
+
 func TestWidthFoldOption(t *testing.T) {
 	defaultOut, err := SearchPreset().Run("Ｇｏ")
 	if err != nil {

--- a/textnorm/unicode.go
+++ b/textnorm/unicode.go
@@ -1,6 +1,7 @@
 package textnorm
 
 import (
+	"strings"
 	"unicode"
 
 	"golang.org/x/text/runes"
@@ -35,4 +36,34 @@ func normalizeUnicodeStage(s string) (string, error) {
 	}
 
 	return result, nil
+}
+
+// NormalizeUnicodeLatin appends a script-aware diacritic-removal stage:
+// combining marks (Mn) are removed ONLY when their base character is Latin.
+// Latin "café"→"cafe", but Devanagari matras and Arabic harakat — which are
+// meaning-bearing vowels, not decorations — survive intact.
+func (p Pipeline) NormalizeUnicodeLatin() Pipeline {
+	return p.Then(normalizeUnicodeLatinStage)
+}
+
+func normalizeUnicodeLatinStage(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	decomposed := norm.NFD.String(s)
+	var b strings.Builder
+	b.Grow(len(decomposed))
+	lastBaseLatin := false
+	for _, r := range decomposed {
+		if unicode.Is(unicode.Mn, r) {
+			if lastBaseLatin {
+				continue
+			}
+			b.WriteRune(r)
+			continue
+		}
+		lastBaseLatin = unicode.Is(unicode.Latin, r)
+		b.WriteRune(r)
+	}
+	return norm.NFC.String(b.String()), nil
 }

--- a/textnorm/unicode_test.go
+++ b/textnorm/unicode_test.go
@@ -21,3 +21,23 @@ func TestRemoveAccentsMatchesNormalizeUnicode(t *testing.T) {
 		t.Fatalf("Run() = %q, want %q", got, "naive")
 	}
 }
+
+func TestNormalizeUnicodeLatin(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"latin accents stripped", "Caf\u00e9 Cr\u00e8me Herm\u00e8s", "Cafe Creme Hermes"},
+		{"devanagari matras preserved", "\u0915\u093f\u0924\u093e\u092c", "\u0915\u093f\u0924\u093e\u092c"},
+		{"arabic harakat preserved", "\u0645\u064e\u0643\u062a\u064e\u0628", "\u0645\u064e\u0643\u062a\u064e\u0628"},
+		{"mixed latin+indic", "caf\u00e9 \u0915\u093f\u0924\u093e\u092c", "cafe \u0915\u093f\u0924\u093e\u092c"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := New().NormalizeUnicodeLatin().Run(c.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("NormalizeUnicodeLatin(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Four new pipeline stages and two presets for meaning-preserving text normalization:

- **PreserveMeaningPunct** — rejected runes become spaces (never deleted, so tokens don't merge: `2.5`→`2 5` under old FilterRunes deletion became `25`). Keeps `.`/`,` between digits (`4.5`, `1,000` — separators NOT unified), token-final `+` (`s22+`, `c++`), `%` after digit (`100%`). Combining marks (Mn/Mc/Me) are kept — Devanagari matras and Arabic harakat are vowels, not punctuation.
- **NormalizeUnicodeLatin** — strips diacritics ONLY from Latin base characters. `café`→`cafe`, but `किताब` and `مَكتَب` survive intact (the existing `NormalizeUnicode` removes ALL Mn marks, destroying Indic/Arabic vowel signs).
- **DecodeHTMLEntities** / **RemoveFormatChars** — byte hygiene: entity decoding, Cf/Cc removal (except `\n`/`\t`).
- **MeaningPreset** = SanitizeUTF8 → DecodeHTMLEntities → NormalizeUnicodeLatin → [FoldWidth] → FoldCase → PreserveMeaningPunct → TrimSpace → CollapseWhitespace. No token dedup. For content hashes where `Galaxy S22+` must not collide with `Galaxy S22`.
- **HygienePreset** = SanitizeUTF8 → DecodeHTMLEntities → RemoveFormatChars → [FoldWidth] → TrimSpace → CollapseWhitespace. For model payloads — case/punctuation/diacritics preserved.

## Why

Downstream consumers (framework-golang textpipe → veliu.com embeddings) need a fingerprint preset that doesn't destroy meaning and a payload-grade hygiene preset. Existing presets are intentionally untouched (byte-identical behavior).

## Testing

- Golden tests pin the distinctions: `s22+`≠`s22`, `4.5`≠`45`, `1,000`≠`1 000`, no dedup, Indic/Arabic preserved.
- `FuzzMeaningPreset` (20s run clean): output alphabet restricted to letters/numbers/marks/space/`.,+%`, no uncollapsed whitespace.
- Full module: 683 tests green, `go vet` clean.

Release: will tag **v1.3.0** after merge.